### PR TITLE
feat(issue-6): Se ajusta servicio que elimina un empleado validando si esta asociado a un grupo

### DIFF
--- a/src/main/java/com/infragest/infra_groups_service/controller/GroupsController.java
+++ b/src/main/java/com/infragest/infra_groups_service/controller/GroupsController.java
@@ -183,10 +183,10 @@ public class GroupsController {
             @ApiResponse(responseCode = "500", description = "Error interno del servidor",
                     content = @Content(mediaType = "application/json", schema = @Schema(implementation = ErrorResponse.class)))
     })
-    @DeleteMapping("/{id}/employees/{employeeId}")
-    public ResponseEntity<Void> removeEmployee(@PathVariable("id") UUID id,
+    @DeleteMapping("/{groupId}/employees/{employeeId}")
+    public ResponseEntity<Void> removeEmployee(@PathVariable("groupId") UUID groupId,
                                                @PathVariable("employeeId") UUID employeeId) {
-        groupService.removeEmployee(id, employeeId);
+        groupService.removeEmployee(groupId, employeeId);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/infragest/infra_groups_service/model/GroupRq.java
+++ b/src/main/java/com/infragest/infra_groups_service/model/GroupRq.java
@@ -17,9 +17,16 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class GroupRq {
 
+    /**
+     * Nombre del grupo.
+     */
     @NotBlank(message = "name no puede estar vacío")
     private String name;
 
+    /**
+     * Dirección de la oficina donde se encuentra ubicados los equipos.
+     */
     @NotBlank(message = "address no puede estar vacío")
     private String address;
+
 }

--- a/src/main/java/com/infragest/infra_groups_service/repository/GroupsRepository.java
+++ b/src/main/java/com/infragest/infra_groups_service/repository/GroupsRepository.java
@@ -30,6 +30,11 @@ public interface GroupsRepository extends JpaRepository<Group, UUID> {
      */
     boolean existsByNameIgnoreCase(String name);
 
-
+    /**
+     * Comprueba si existe un empleado asociado a un grupo o mas.
+     *
+     * @param employeeId
+     * @return true si existe o false en caso de que no exista
+     */
     boolean existsByEmployees_Id(UUID employeeId);
 }

--- a/src/main/java/com/infragest/infra_groups_service/repository/GroupsRepository.java
+++ b/src/main/java/com/infragest/infra_groups_service/repository/GroupsRepository.java
@@ -29,4 +29,7 @@ public interface GroupsRepository extends JpaRepository<Group, UUID> {
      * @return true si existe al menos un Group con ese name (case-insensitive)
      */
     boolean existsByNameIgnoreCase(String name);
+
+
+    boolean existsByEmployees_Id(UUID employeeId);
 }

--- a/src/main/java/com/infragest/infra_groups_service/service/impl/EmployeeServiceImpl.java
+++ b/src/main/java/com/infragest/infra_groups_service/service/impl/EmployeeServiceImpl.java
@@ -1,12 +1,14 @@
 package com.infragest.infra_groups_service.service.impl;
 
 import com.infragest.infra_groups_service.entity.Employees;
+import com.infragest.infra_groups_service.entity.Group;
 import com.infragest.infra_groups_service.enums.EmployeStatus;
 import com.infragest.infra_groups_service.exception.EmployeeException;
 import com.infragest.infra_groups_service.model.EmployeeRq;
 import com.infragest.infra_groups_service.model.EmployeeRs;
 import com.infragest.infra_groups_service.model.EmployeeSummaryDto;
 import com.infragest.infra_groups_service.repository.EmployeesRepository;
+import com.infragest.infra_groups_service.repository.GroupsRepository;
 import com.infragest.infra_groups_service.service.EmployeeService;
 import com.infragest.infra_groups_service.util.MessageException;
 import lombok.extern.slf4j.Slf4j;
@@ -37,11 +39,18 @@ public class EmployeeServiceImpl implements EmployeeService {
     private final EmployeesRepository employeesRepository;
 
     /**
+     * Inyección de dependencia: GroupsRepository
+     */
+    private final GroupsRepository groupsRepository;
+
+    /**
      * Crea un constructor con los repositorios necesarios para el servicio.
      * @param employeesRepository
+     * @param groupsRepository
      */
-    public EmployeeServiceImpl(EmployeesRepository employeesRepository) {
+    public EmployeeServiceImpl(EmployeesRepository employeesRepository, GroupsRepository groupsRepository) {
         this.employeesRepository = employeesRepository;
+        this.groupsRepository = groupsRepository;
     }
 
     /**
@@ -210,6 +219,12 @@ public class EmployeeServiceImpl implements EmployeeService {
                         log.debug("Employee not found for deletion: {}", id);
                         return new EmployeeException(msg, EmployeeException.Type.NOT_FOUND);
                     });
+
+            // Validar si el empleado existe en por lo menos un grupo.
+            if (groupsRepository.existsByEmployees_Id(existing.getId())) {
+                throw new EmployeeException(String.format(MessageException.EMPLOYEE_CANNOT_BE_REMOVED_FROM_GROUP, existing.getId()), EmployeeException.Type.BAD_REQUEST);
+            }
+
             employeesRepository.delete(existing);
             log.info("Employee {} deleted", id);
         } catch (DataAccessException dae) {

--- a/src/main/java/com/infragest/infra_groups_service/util/MessageException.java
+++ b/src/main/java/com/infragest/infra_groups_service/util/MessageException.java
@@ -19,6 +19,7 @@ public abstract class MessageException {
     public static final String EMPLOYEE_ALREADY_EXISTS = "Employee ya existe: %s";
     public static final String EMPLOYEE_NOT_FOUND_IN_GROUP = "No existen empleados en el grupo: %s";
     public static final String EMPLOYEE_NO_VALID_EMAILS_IN_GROUP = "No hay correos válidos asociados al grupo: %s";
+    public static final String EMPLOYEE_CANNOT_BE_REMOVED_FROM_GROUP = "El empleado %s no puede ser eliminado porque está asociado a uno o más grupos.";
 
     public static final String INVALID_EMPLOYEE_LIST = "Lista de empleados inválida";
     public static final String INVALID_REQUEST = "Request inválido";


### PR DESCRIPTION
# 🚀 Pull Request

## Descripción

- Se implementa validación para verificar si un empleado, antes de ser eliminado, está asociado a uno o más grupos.
- Se documenta el DTO `GroupRq`.
- Se crean los mensajes de excepciones personalizados, siguiendo el estándar documental del proyecto.

## ¿Qué tipo de cambio es?
- [x] Bugfix 🐞
- [ ] Feature ✨
- [ ] Refactor 🔧
- [x] Documentación 📚
- [ ] Otro

## ¿Cómo probar estos cambios?
- Intentar eliminar un empleado asociado a un grupo determinado. Verificar que aparece el mensaje de error correspondiente (`El empleado no puede ser eliminado porque está asociado a uno o más grupos`).

- Intentar eliminar un empleado que no tenga asociación con ningún grupo. Verificar que el empleado es eliminado correctamente sin errores.

## Checklist
- [x] El código compila y pasa los tests
- [x] La documentación está actualizada (si aplica)
- [x] No hay warnings nuevos
- [x] Revisé el formato y convenciones de código

## Screenshots (si aplica)
Nn

## Issue relacionada
Nn

## Notas para el revisor
Nn
