### PR TITLE
Merge main to dev 

### DIFF
--- a/src/main/java/com/infragest/infra_groups_service/service/impl/GroupServiceImpl.java
+++ b/src/main/java/com/infragest/infra_groups_service/service/impl/GroupServiceImpl.java
@@ -278,8 +278,7 @@ public class GroupServiceImpl implements GroupService {
             missing.removeAll(foundIds);
             if (!missing.isEmpty()) {
                 UUID missingId = missing.iterator().next();
-                log.debug("Employee not found when assigning to group {}: {}", id, missingId);
-                throw new GroupException(String.format(MessageException.EMPLOYEE_NOT_FOUND, missingId), GroupException.Type.BAD_REQUEST);
+                log.info("Employee not found when assigning to group {}: {}", id, missingId);
             }
 
             // Comprobar estado y pertenencia actual
@@ -289,26 +288,33 @@ public class GroupServiceImpl implements GroupService {
                     .map(Employees::getId)
                     .collect(Collectors.toSet());
 
-            for (Employees e : found) {
-                // Validar estado (asumimos que status.toString() contiene algo como "ACTIVE")
-                String status = String.valueOf(e.getStatus());
-                if (status == null || !"ACTIVE".equalsIgnoreCase(status)) {
-                    log.warn("Attempt to assign inactive employee {} to group {}", e.getId(), id);
-                    throw new GroupException(String.format(MessageException.EMPLOYEE_NOT_ACTIVE, e.getId()), GroupException.Type.BAD_REQUEST);
-                }
+            // // Filtra empleados activos que no estén registrados en el grupo y genera advertencias si el empleado está inactivo o ya pertenece al grupo.
+            List<Employees> toAssign = found.stream()
+                    .filter(e -> {
+                        boolean alreadyInGroup = existingEmployeeIds.contains(e.getId());
+                        boolean isActive = e.getStatus() != null && "ACTIVE".equalsIgnoreCase(String.valueOf(e.getStatus()));
+                        if (alreadyInGroup) {
+                            log.warn("Attempt to assign employee {} who is already in group {}", e.getId(), id);
+                        }
+                        if (!isActive) {
+                            log.warn("Attempt to assign inactive employee {} to group {}", e.getId(), id);
+                        }
+                        return !alreadyInGroup && isActive;
+                    })
+                    .collect(Collectors.toList());
 
-                // Validar si ya pertenece
-                if (existingEmployeeIds.contains(e.getId())) {
-                    log.warn("Attempt to assign employee {} who is already in group {}", e.getId(), id);
-                    throw new GroupException(String.format(MessageException.EMPLOYEE_ALREADY_IN_GROUP, e.getId()), GroupException.Type.BAD_REQUEST);
-                }
+            if (toAssign.isEmpty()) {
+                throw new GroupException(
+                        MessageException.NO_VALID_EMPLOYEES_TO_ASSIGN,
+                        GroupException.Type.BAD_REQUEST
+                );
             }
 
             // Asignar todos los empleados (añadir al Set)
             if (existing.getEmployees() == null) {
-                existing.setEmployees(new HashSet<>(found));
+                existing.setEmployees(new HashSet<>(toAssign));
             } else {
-                existing.getEmployees().addAll(found);
+                existing.getEmployees().addAll(toAssign);
             }
 
             Group saved = groupRepository.save(existing);

--- a/src/main/java/com/infragest/infra_groups_service/util/MessageException.java
+++ b/src/main/java/com/infragest/infra_groups_service/util/MessageException.java
@@ -28,5 +28,6 @@ public abstract class MessageException {
     public static final String OPERATION_NOT_ALLOWED = "Operation not allowed: %s";
     public static final String DATABASE_ERROR = "Database error";
     public static final String INTERNAL_ERROR = "Internal server error";
+    public static final String NO_VALID_EMPLOYEES_TO_ASSIGN = "There aren't any valid employees to assign to the group";
 
 }


### PR DESCRIPTION
# 🚀 Pull Request

## Descripción

- Se refactorizó el método que asigna empleados a un grupo específico. Ahora, si un empleado no está activo, ya se encuentra en el grupo, o presenta algún otro error, el proceso no se interrumpe y continúa con los demás empleados de la lista. Así se garantiza que el flujo de asignación se complete correctamente.

## ¿Qué tipo de cambio es?
- [ ] Bugfix 🐞
- [x] Feature ✨
- [x] Refactor 🔧
- [x] Documentación 📚
- [x] Otro

## ¿Cómo probar estos cambios?
- Consumir el servicio que asigna empleados a un grupo y verificar que realiza el flujo correctamente y no se detiene si encuentra algún error con um empleado.

## Checklist
- [x] El código compila y pasa los tests
- [x] La documentación está actualizada (si aplica)
- [x] No hay warnings nuevos
- [x] Revisé el formato y convenciones de código

## Screenshots (si aplica)
<!-- Adjunta capturas si hay cambios visuales. -->

## Issue relacionada
<!-- Si hay issues asociadas, referencia: closes #123 -->

## Notas para el revisor
<!-- Información extra útil para quien revisa el PR -->
