### PR TITLE
Merge Main to Dev

### DIFF
--- a/src/main/java/com/infragest/infra_groups_service/model/EmployeeRs.java
+++ b/src/main/java/com/infragest/infra_groups_service/model/EmployeeRs.java
@@ -20,6 +20,8 @@ public class EmployeeRs {
     private String fullName;
     private String email;
     private EmployeStatus status;
+    private String documentType;
+    private String documentNumber;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private Long version;

--- a/src/main/java/com/infragest/infra_groups_service/service/impl/EmployeeServiceImpl.java
+++ b/src/main/java/com/infragest/infra_groups_service/service/impl/EmployeeServiceImpl.java
@@ -246,6 +246,8 @@ public class EmployeeServiceImpl implements EmployeeService {
         r.setFullName(e.getFullName());
         r.setEmail(e.getEmail());
         r.setStatus(e.getStatus());
+        r.setDocumentType(e.getDocumentType());
+        r.setDocumentNumber(e.getDocumentNumber());
         r.setCreatedAt(e.getCreatedAt());
         r.setUpdatedAt(e.getUpdatedAt());
         r.setVersion(e.getVersion());


### PR DESCRIPTION
# 🚀 Pull Request

## Descripción
Se amplía la respuesta del servicio de grupos para incluir la información de **tipo de documento** y **número de documento** en el DTO `EmployeeRs`.

Con este cambio, cuando el microservicio de grupos retorna información de empleados asociados, ahora expone también:
- `documentType`
- `documentNumber`

Además, se actualiza el mapeo en `EmployeeServiceImpl` para poblar estos nuevos campos desde la entidad `Employees`.

## ¿Qué tipo de cambio es?
- [x] Bugfix 🐞
- [ ] Feature ✨
- [ ] Refactor 🔧
- [ ] Documentación 📚
- [ ] Otro

## ¿Cómo probar estos cambios?
1. Compilar el proyecto:
   ```bash
   ./mvnw clean verify
   ```

2. Levantar el servicio:
   ```bash
   ./mvnw spring-boot:run
   ```

3. Consumir un endpoint que retorne empleados desde el microservicio de grupos, por ejemplo uno de:
   - detalle de grupo
   - listado de empleados asociados a grupo
   - cualquier endpoint que serialice `EmployeeRs`

4. Verificar en la respuesta JSON que ahora estén presentes los campos:
   - `documentType`
   - `documentNumber`

5. Confirmar que los valores correspondan con los datos persistidos en base de datos para ese empleado.

## Checklist
- [x] El código compila y pasa los tests
- [ ] La documentación está actualizada (si aplica)
- [x] No hay warnings nuevos
- [x] Revisé el formato y convenciones de código

## Screenshots (si aplica)
No aplica.

## Issue relacionada
<!-- Si hay issues asociadas, referencia: closes #123 -->

## Notas para el revisor
- El cambio es pequeño pero impacta el contrato de salida de `EmployeeRs`.
- No modifica lógica de negocio; solo amplía el DTO y su mapeo.
- Revisar si existen consumidores frontend o integraciones que ya esperen estos campos para aprovecharlos.
- También conviene validar que no haya efectos colaterales en serialización, documentación OpenAPI o tests de snapshots/respuesta si existen.