### PR TITLE
feat(issue-8): Se agrega tipoDocumento y numero dentro de la persistencia al actualizar un empleado

### DIFF
--- a/src/main/java/com/infragest/infra_groups_service/service/impl/EmployeeServiceImpl.java
+++ b/src/main/java/com/infragest/infra_groups_service/service/impl/EmployeeServiceImpl.java
@@ -189,6 +189,12 @@ public class EmployeeServiceImpl implements EmployeeService {
             if (rq.getStatus() != null) {
                 existing.setStatus(rq.getStatus());
             }
+            if (rq.getDocumentType() != null) {
+                existing.setDocumentType(rq.getDocumentType());
+            }
+            if (rq.getDocumentNumber() != null) {
+                existing.setDocumentNumber(rq.getDocumentNumber());
+            }
 
             Employees saved = employeesRepository.save(existing);
             return toRs(saved);


### PR DESCRIPTION
# 🚀 Pull Request

## Descripción
Se corrige el flujo de actualización de empleados en el microservicio de grupos para permitir modificar también los campos de **tipo de documento** y **número de documento**.

Antes de este cambio, el método `updateEmployee` actualizaba campos como nombre, email y estado, pero no persistía cambios en:
- `documentType`
- `documentNumber`

Ahora ambos campos son tenidos en cuenta durante la actualización cuando vienen informados en `EmployeeRq`.

## ¿Qué tipo de cambio es?
- [x] Bugfix 🐞
- [ ] Feature ✨
- [ ] Refactor 🔧
- [ ] Documentación 📚
- [ ] Otro

## ¿Cómo probar estos cambios?
1. Compilar el proyecto:
   ```bash
   ./mvnw clean verify
   ```

2. Levantar el servicio:
   ```bash
   ./mvnw spring-boot:run
   ```

3. Ejecutar una actualización de empleado contra el endpoint correspondiente, enviando un body que incluya:
   - `documentType`
   - `documentNumber`

   Ejemplo:
   ```json
   {
     "fullName": "Juan Pérez",
     "email": "juan@test.com",
     "status": "ACTIVE",
     "documentType": "CC",
     "documentNumber": "123456789"
   }
   ```

4. Verificar que la respuesta del endpoint retorne los nuevos valores actualizados.

5. Consultar nuevamente el empleado y confirmar que los cambios quedaron persistidos en base de datos.

6. Validar que la actualización siga funcionando correctamente para los demás campos ya soportados.

## Checklist
- [x] El código compila y pasa los tests
- [ ] La documentación está actualizada (si aplica)
- [x] No hay warnings nuevos
- [x] Revisé el formato y convenciones de código

## Screenshots (si aplica)
No aplica.

## Issue relacionada
<!-- Si hay issues asociadas, referencia: closes #123 -->

## Notas para el revisor
- El cambio está acotado al método `updateEmployee`.
- No se altera la estructura del DTO de request; solo se empieza a respetar el mapeo de dos campos que antes no se aplicaban.
- Esto corrige una inconsistencia entre los datos aceptados por el request y los realmente persistidos en la entidad.

